### PR TITLE
Remove unhandled exception handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+###
+The only difference between this fork and upstream is that this one does not
+hijack 'uncaughtException' handlers your application might have
+
 ### enet
 emscripten compiled [enet networking library](http://enet.bespin.org/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###
+### Why fork?
 The only difference between this fork and upstream is that this one does not
 hijack 'uncaughtException' handlers your application might have
 

--- a/index.js
+++ b/index.js
@@ -24,11 +24,3 @@ enet.init = function (func) {
 	jsapi_.init(funcPointer);
 };
 
-process.removeAllListeners("uncaughtException"); //emscripten catches and throws again!
-process.on("uncaughtException", function (e) {
-	//catch uncaught exceptions
-	// node's .bind() on dgram sockets throws an async exception
-	// it will be caught in socket.on("error") in createHost();
-	// but we catch the exception here to prevent app crashing
-	console.error("uncaught exception:", e);
-});


### PR DESCRIPTION
We are using enet heavily in our application and it is very useful, thank you for creating it.

However - it has one critical side effect.

Our application has its own exception handler that logs the error along with some 
diagnostic data and raises alert.

A simple require('enet') call completely removes our exception handler and replaces it
with its own that is a lot less useful for our usecase.

Would you consider removing that code? 
